### PR TITLE
[7.x] Always wrap date parsing exception into IllegalArgumentException (#71038)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/time/JavaDateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/JavaDateFormatter.java
@@ -177,7 +177,7 @@ class JavaDateFormatter implements DateFormatter {
 
         try {
             return doParse(input);
-        } catch (DateTimeParseException e) {
+        } catch (Exception e) {
             throw new IllegalArgumentException("failed to parse date field [" + input + "] with format [" + format + "]", e);
         }
     }

--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -60,6 +60,11 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
             runtimeJdk8);
     }
 
+    public void testIncorrectFormat() {
+        assertParseException("2021-01-01T23-35-00Z", "strict_date_optional_time||epoch_millis");
+        assertParseException("2021-01-01T23-35-00Z", "strict_date_optional_time");
+    }
+
     public void testTimezoneParsing() {
         /** this testcase won't work in joda. See comment in {@link #testPartialTimeParsing()}
          *  assertSameDateAs("2016-11-30T+01", "strict_date_optional_time", "strict_date_optional_time");

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -205,6 +205,17 @@ public class DynamicMappingTests extends MapperServiceTestCase {
             "{\"_doc\":{\"properties\":{\"foo\":{\"type\":\"text\",\"fields\":" +
                 "{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}}}}}",
             Strings.toString(doc.dynamicMappingsUpdate()));
+
+    }
+
+    public void testDynamicFieldOnIncorrectDate() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
+        ParsedDocument doc = mapper.parse(source(b -> b.field("foo", "2020-01-01T01-01-01Z")));
+        assertNotNull(doc.dynamicMappingsUpdate());
+        assertEquals(
+            "{\"_doc\":{\"properties\":{\"foo\":{\"type\":\"text\",\"fields\":" +
+                "{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}}}}}",
+            Strings.toString(doc.dynamicMappingsUpdate()));
     }
 
     public void testDynamicUpdateWithRuntimeField() throws Exception {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Always wrap date parsing exception into IllegalArgumentException (#71038)