### PR TITLE
Add docker tests

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.http.client.fluent.Request;
+import org.elasticsearch.packaging.util.FileUtils;
 import org.elasticsearch.packaging.util.Installation;
 import org.elasticsearch.packaging.util.Platforms;
 import org.elasticsearch.packaging.util.ProcessInfo;
@@ -1220,5 +1221,22 @@ public class DockerTests extends PackagingTestCase {
         );
         waitForElasticsearch(installation);
         assertTrue(readinessProbe(9399));
+    }
+
+    public void test600Interrupt() {
+        waitForElasticsearch(installation, "elastic", PASSWORD);
+        final Result containerLogs = getContainerLogs();
+
+        assertThat("Container logs should contain starting ...", containerLogs.stdout(), containsString("starting ..."));
+
+        final List<ProcessInfo> infos = ProcessInfo.getProcessInfo(sh, "java");
+        final int maxPid = infos.stream().map(i -> i.pid()).max(Integer::compareTo).get();
+
+        sh.run("kill -int " + maxPid); // send ctrl+c to all java processes
+        final Result containerLogsAfter = getContainerLogs();
+
+        assertThat("Container logs should contain stopping ...", containerLogsAfter.stdout(), containsString("stopping ..."));
+        assertThat("No errors stdout", containerLogsAfter.stdout(), not(containsString("java.security.AccessControlException:")));
+        assertThat("No errors stderr", containerLogsAfter.stderr(), not(containsString("java.security.AccessControlException:")));
     }
 }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.http.client.fluent.Request;
-import org.elasticsearch.packaging.util.FileUtils;
 import org.elasticsearch.packaging.util.Installation;
 import org.elasticsearch.packaging.util.Platforms;
 import org.elasticsearch.packaging.util.ProcessInfo;


### PR DESCRIPTION
This change adds a docker test that we can use to detect we never have these kinds of issues again. It tests against any security manager errors if the process is interrupted. When I ran this locally I got this at the end of the output:

Command:
```
./gradlew ':qa:os:destructiveDistroTest.default-docker' -Dtests.class="org.elasticsearch.packaging.test.DockerTests" -Dtests.method="test600Interrupt"
```

Output:
```
n{\"@timestamp\":\"2022-11-22T23:52:54.974Z\", \"log.level\":\"ERROR\", \"message\":\"uncaught exception in thread [process reaper (pid 274)]\", \"ecs.version\": \"1.2.0\",\"service.name\":\"ES_ECS\",\"event.dataset\":\"elasticsearch.server\",\"process.thread.name\":\"process reaper (pid 274)\",\"log.logger\":\"org.elasticsearch.bootstrap.ElasticsearchUncaughtExceptionHandler\",\"elasticsearch.cluster.uuid\":\"fzcOi22ITwGNhusZL02-OQ\",\"elasticsearch.node.id\":\"ln-wz794T-qVLhi9vz2xeA\",\"elasticsearch.node.name\":\"955b6765340a\",\"error.type\":\"java.security.AccessControlException\",\"error.message\":\"access denied (\\\"java.lang.RuntimePermission\\\" \\\"modifyThread\\\")\",\"error.stack_trace\":\"java.security.AccessControlException: access denied (\\\"java.lang.RuntimePermission\\\" \\\"modifyThread\\\")\\n\\tat java.base/java.security.AccessControlContext.checkPermission(AccessControlContext.java:485)\\n\\tat java.base/java.security.AccessController.checkPermission(AccessController.java:1068)\\n\\tat java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:411)\\n\\tat org.elasticsearch.securesm@8.7.0-SNAPSHOT/org.elasticsearch.secure_sm.SecureSM.checkThreadAccess(SecureSM.java:166)\\n\\tat org.elasticsearch.securesm@8.7.0-SNAPSHOT/org.elasticsearch.secure_sm.SecureSM.checkAccess(SecureSM.java:120)\\n\\tat java.base/java.lang.Thread.checkAccess(Thread.java:2360)\\n\\tat java.base/java.lang.Thread.setDaemon(Thread.java:2308)\\n\\tat java.base/java.lang.ProcessHandleImpl.lambda$static$0(ProcessHandleImpl.java:103)\\n\\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.<init>(ThreadPoolExecutor.java:637)\\n\\tat java.base/java.util.concurrent.ThreadPoolExecutor.addWorker(ThreadPoolExecutor.java:928)\\n\\tat java.base/java.util.concurrent.ThreadPoolExecutor.processWorkerExit(ThreadPoolExecutor.java:1021)\\n\\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1158)\\n\\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)\\n\\tat java.base/java.lang.Thread.run(Thread.java:1589)\\n\\tat java.base/jdk.internal.misc.InnocuousThread.run(InnocuousThread.java:186)\\n\"}\n{\"@timestamp\":\"2022-11-22T23:52:55.017Z\", \"log.level\": \"INFO\", \"message\":\"stopped\", \"ecs.version\": \"1.2.0\",\"service.name\":\"ES_ECS\",\"event.dataset\":\"elasticsearch.server\",\"process.thread.name\":\"Thread-0\",\"log.logger\":\"org.elasticsearch.node.Node\",\"elasticsearch.cluster.uuid\":\"fzcOi22ITwGNhusZL02-OQ\",\"elasticsearch.node.id\":\"ln-wz794T-qVLhi9vz2xeA\",\"elasticsearch.node.name\":\"955b6765340a\",\"elasticsearch.cluster.name\":\"docker-cluster\"}\n{\"@timestamp\":\"2022-11-22T23:52:55.017Z\", \"log.level\": \"INFO\", \"message\":\"closing ...\", \"ecs.version\": \"1.2.0\",\"service.name\":\"ES_ECS\",\"event.dataset\":\"elasticsearch.server\",\"process.thread.name\":\"Thread-0\",\"log.logger\":\"org.elasticsearch.node.Node\",\"elasticsearch.cluster.uuid\":\"fzcOi22ITwGNhusZL02-OQ\",\"elasticsearch.node.id\":\"ln-wz794T-qVLhi9vz2xeA\",\"elasticsearch.node.name\":\"955b6765340a\",\"elasticsearch.cluster.name\":\"docker-cluster\"}"
        at __randomizedtesting.SeedInfo.seed([AF786F647C0CB8F4:3593DC661C13C582]:0)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
        at org.junit.Assert.assertThat(Assert.java:956)
        at org.elasticsearch.packaging.test.DockerTests.test600Interrupt(DockerTests.java:1239)
```